### PR TITLE
Fix missing CSS animations

### DIFF
--- a/style.css
+++ b/style.css
@@ -99,6 +99,16 @@ body::before {
     100% { transform: rotate(360deg); }
 }
 
+@keyframes aparecer {
+    from { opacity: 0; transform: translateY(-10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes piscar {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+}
+
 .mensagem {
     position: absolute;
     top: -80px;


### PR DESCRIPTION
## Summary
- add `aparecer` and `piscar` keyframes so messages animate correctly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68407e7290a48330bc6ed5d4684a5bcf